### PR TITLE
Added tap config for google-sheets

### DIFF
--- a/pipelinewise/cli/schemas/tap.json
+++ b/pipelinewise/cli/schemas/tap.json
@@ -213,6 +213,7 @@
         "tap-jira",
         "tap-zuora",
         "tap-google-analytics",
+        "tap-google-sheets",
         "tap-github",
         "tap-shopify",
         "tap-slack",

--- a/pipelinewise/cli/tap_properties.py
+++ b/pipelinewise/cli/tap_properties.py
@@ -266,6 +266,14 @@ def get_tap_properties(tap=None, temp_dir=None):
             'default_replication_method': 'LOG_BASED',
             'default_data_flattening_max_level': 0
         },
+        'tap-google-sheets': {
+            'tap_config_extras': {},
+            'tap_stream_id_pattern': '{{table_name}}',
+            'tap_stream_name_pattern': '{{table_name}}',
+            'tap_catalog_argument': '--catalog',
+            'default_replication_method': 'LOG_BASED',
+            'default_data_flattening_max_level': 0
+        },
         # Default values to use as a fallback method
         'DEFAULT': {
             'tap_config_extras': {},

--- a/singer-connectors/tap-google-sheets/requirements.txt
+++ b/singer-connectors/tap-google-sheets/requirements.txt
@@ -1,0 +1,2 @@
+#tap-google-sheets==1.0.4
+git+git://github.com/Health-Union/tap-google-sheets@master


### PR DESCRIPTION
## Problem

Pipeline wise has no google-sheets tap

## Proposed changes

Allows HU fork of tap-google-sheets to be used in pipeline configurations
(there are issues with the tap, but those need to be addressed in the tap itself, I think)


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
