### PR TITLE
removed AWS Key and ID param requirements so Boto can self-authenticate

### DIFF
--- a/pipelinewise/fastsync/s3_csv_to_snowflake.py
+++ b/pipelinewise/fastsync/s3_csv_to_snowflake.py
@@ -18,8 +18,6 @@ LOGGER = Logger().get_logger(__name__)
 
 REQUIRED_CONFIG_KEYS = {
     'tap': [
-        'aws_access_key_id',
-        'aws_secret_access_key',
         'bucket',
         'start_date'
     ],


### PR DESCRIPTION
## Problem
AWS_ACCESS_KEY and AWS_SECRET_ACCESS_KEY are not required key parameters, depending on your AWS implementation. 

Boto will traverse the entire auth stack - that includes ~/.aws/credentials, these envars, and finally IAM service discovery; so making these optional allows the tap to use whichever native auth is best for your use case.
Currently requiring these params means PPW can't be run in AWS with IAM service discovery :(

## Proposed changes
Allowing the K/V pair to be optional lets Boto do what it does: look for the best possible, most secure way 
to auth and go with that. 

## Types of changes
simply remove the AWS key and id params from required params. 

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
