### PR TITLE
Feature/data 1128/use hu snowflake tap

### DIFF
--- a/singer-connectors/target-snowflake/requirements.txt
+++ b/singer-connectors/target-snowflake/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-target-snowflake==1.8.0
+git+git://github.com/Health-Union/pipelinewise-target-snowflake


### PR DESCRIPTION
## Why?
points our ppw fork to the HU fork of snowflake-target that uses snowpipe.

##  what changes?
- now pulls via git for the sf target

## how does this impact me? 
we can now update the ppw template to use snowpipe!  