### PR TITLE
Feature/data 1128/snowpipe filter fastsync

### DIFF
--- a/pipelinewise/fastsync/commons/tap_s3_csv.py
+++ b/pipelinewise/fastsync/commons/tap_s3_csv.py
@@ -260,16 +260,13 @@ class S3Helper:
     @classmethod
     @retry_pattern()
     def setup_aws_client(cls, config):
-        aws_session_parms = dict(
-            profile_name=config.get('aws_profile', None) or os.environ.get('AWS_PROFILE'),
-            aws_access_key_id=config.get('aws_access_key_id', None) or os.environ.get('AWS_ACCESS_KEY_ID'),
-            aws_secret_access_key=config.get('aws_secret_access_key', None) or \
-                                os.environ.get('AWS_SECRET_ACCESS_KEY'),
-            aws_session_token=config.get('aws_session_token', None) or os.environ.get('AWS_SESSION_TOKEN')
-        )
+        aws_session_params = dict()
+        for val in ("aws_profile", "aws_access_key_id", "aws_secret_access_key", "aws_session_token"):
+            if found_val := config.get(val) or os.environ.get(val.upper()):
+                aws_session_params[val] = found_val
 
         LOGGER.info('Attempting to create AWS session')
-        boto3.setup_default_session(**aws_session_parms)
+        boto3.setup_default_session(**aws_session_params)
 
     @classmethod
     def get_input_files_for_table(cls, config: Dict, table_spec: Dict, modified_since: struct_time = None):

--- a/pipelinewise/fastsync/commons/tap_s3_csv.py
+++ b/pipelinewise/fastsync/commons/tap_s3_csv.py
@@ -3,6 +3,7 @@ import gzip
 import logging
 import re
 import sys
+import os
 import boto3
 
 from datetime import datetime
@@ -259,12 +260,16 @@ class S3Helper:
     @classmethod
     @retry_pattern()
     def setup_aws_client(cls, config):
-        aws_access_key_id = config['aws_access_key_id']
-        aws_secret_access_key = config['aws_secret_access_key']
+        aws_session_parms = dict(
+            profile_name=config.get('aws_profile', None) or os.environ.get('AWS_PROFILE'),
+            aws_access_key_id=config.get('aws_access_key_id', None) or os.environ.get('AWS_ACCESS_KEY_ID'),
+            aws_secret_access_key=config.get('aws_secret_access_key', None) or \
+                                os.environ.get('AWS_SECRET_ACCESS_KEY'),
+            aws_session_token=config.get('aws_session_token', None) or os.environ.get('AWS_SESSION_TOKEN')
+        )
 
         LOGGER.info('Attempting to create AWS session')
-        boto3.setup_default_session(aws_access_key_id=aws_access_key_id,
-                                    aws_secret_access_key=aws_secret_access_key)
+        boto3.setup_default_session(**aws_session_parms)
 
     @classmethod
     def get_input_files_for_table(cls, config: Dict, table_spec: Dict, modified_since: struct_time = None):

--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -29,22 +29,18 @@ class FastSyncTargetSnowflake:
         self.transformation_config = transformation_config
 
         # Get the required parameters from config file and/or environment variables
-        aws_profile = self.connection_config.get('aws_profile') or os.environ.get('AWS_PROFILE')
-        aws_access_key_id = self.connection_config.get('aws_access_key_id') or os.environ.get('AWS_ACCESS_KEY_ID')
-        aws_secret_access_key = self.connection_config.get('aws_secret_access_key') or \
-                                os.environ.get('AWS_SECRET_ACCESS_KEY')
-        aws_session_token = self.connection_config.get('aws_session_token') or os.environ.get('AWS_SESSION_TOKEN')
+        aws_session_parms = dict(
+            profile_name=self.connection_config.get('aws_profile', None) or os.environ.get('AWS_PROFILE'),
+            aws_access_key_id=self.connection_config.get('aws_access_key_id', None) or \
+                              os.environ.get('AWS_ACCESS_KEY_ID'),
+            aws_secret_access_key=self.connection_config.get('aws_secret_access_key', None) or \
+                                  os.environ.get('AWS_SECRET_ACCESS_KEY'),
+            aws_session_token=self.connection_config.get('aws_session_token', None) or \
+                              os.environ.get('AWS_SESSION_TOKEN')
+        )
 
         # AWS credentials based authentication
-        if aws_access_key_id and aws_secret_access_key:
-            aws_session = boto3.session.Session(
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key,
-                aws_session_token=aws_session_token
-            )
-        # AWS Profile based authentication
-        else:
-            aws_session = boto3.session.Session(profile_name=aws_profile)
+        aws_session = boto3.session.Session(**aws_session_parms)
 
         # Create the s3 client
         self.s3 = aws_session.client('s3',

--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -29,18 +29,13 @@ class FastSyncTargetSnowflake:
         self.transformation_config = transformation_config
 
         # Get the required parameters from config file and/or environment variables
-        aws_session_parms = dict(
-            profile_name=self.connection_config.get('aws_profile', None) or os.environ.get('AWS_PROFILE'),
-            aws_access_key_id=self.connection_config.get('aws_access_key_id', None) or \
-                              os.environ.get('AWS_ACCESS_KEY_ID'),
-            aws_secret_access_key=self.connection_config.get('aws_secret_access_key', None) or \
-                                  os.environ.get('AWS_SECRET_ACCESS_KEY'),
-            aws_session_token=self.connection_config.get('aws_session_token', None) or \
-                              os.environ.get('AWS_SESSION_TOKEN')
-        )
+        aws_session_params = dict()
+        for val in ("aws_profile", "aws_access_key_id", "aws_secret_access_key", "aws_session_token"):
+            if found_val := self.connection_config.get(val) or os.environ.get(val.upper()):
+                aws_session_params[val] = found_val
 
         # AWS credentials based authentication
-        aws_session = boto3.session.Session(**aws_session_parms)
+        aws_session = boto3.session.Session(**aws_session_params)
 
         # Create the s3 client
         self.s3 = aws_session.client('s3',

--- a/pipelinewise/fastsync/s3_csv_to_postgres.py
+++ b/pipelinewise/fastsync/s3_csv_to_postgres.py
@@ -17,8 +17,6 @@ LOGGER = Logger().get_logger(__name__)
 
 REQUIRED_CONFIG_KEYS = {
     'tap': [
-        'aws_access_key_id',
-        'aws_secret_access_key',
         'bucket',
         'start_date'
     ],

--- a/pipelinewise/fastsync/s3_csv_to_redshift.py
+++ b/pipelinewise/fastsync/s3_csv_to_redshift.py
@@ -17,8 +17,6 @@ LOGGER = Logger().get_logger(__name__)
 
 REQUIRED_CONFIG_KEYS = {
     'tap': [
-        'aws_access_key_id',
-        'aws_secret_access_key',
         'bucket',
         'start_date'
     ],


### PR DESCRIPTION
## Problem

Support for transferring data to snowflake using snowpipes is not present in PPW fastsync. 
In production the aws permissions would be picked up from the container and not from the config.

## Proposed changes

Add load_via_snowpipe as a filter for fastsync.
Optional aws credentials, for transfer to Snowflake and PostgreSQL. Data transfers to Redshift without aws keys might lead to failures.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
