### PR TITLE
Bumped tap-google-sheets version to 1.0.6-hu

### DIFF
--- a/singer-connectors/tap-google-sheets/requirements.txt
+++ b/singer-connectors/tap-google-sheets/requirements.txt
@@ -1,1 +1,1 @@
-git+git://github.com/Health-Union/tap-google-sheets@v1.0.5-hu
+git+git://github.com/Health-Union/tap-google-sheets@v1.0.6-hu


### PR DESCRIPTION
## Problem

Updates google sheets tap to the next version that supports shared drives

To be merged after google sheets tap PR is merged and the release 1.0.6-hu tagged.