### PR TITLE
Hotfix walrus operator fix for PPW

### DIFF
--- a/pipelinewise/fastsync/commons/tap_s3_csv.py
+++ b/pipelinewise/fastsync/commons/tap_s3_csv.py
@@ -262,7 +262,9 @@ class S3Helper:
     def setup_aws_client(cls, config):
         aws_session_params = dict()
         for val in ("aws_profile", "aws_access_key_id", "aws_secret_access_key", "aws_session_token"):
-            if found_val := config.get(val) or os.environ.get(val.upper()):
+            found_val = config.get(val) or os.environ.get(val.upper())
+            if found_val:
+                val = "profile_name" if val == "aws_profile" else val
                 aws_session_params[val] = found_val
 
         LOGGER.info('Attempting to create AWS session')

--- a/pipelinewise/fastsync/commons/target_redshift.py
+++ b/pipelinewise/fastsync/commons/target_redshift.py
@@ -31,7 +31,9 @@ class FastSyncTargetRedshift:
         # Get the required parameters from config file and/or environment variables
         aws_session_params = dict()
         for val in ("aws_profile", "aws_access_key_id", "aws_secret_access_key", "aws_session_token"):
-            if found_val := self.connection_config.get(val) or os.environ.get(val.upper()):
+            found_val = self.connection_config.get(val) or os.environ.get(val.upper())
+            if found_val:
+                val = "profile_name" if val == "aws_profile" else val
                 aws_session_params[val] = found_val
 
         # Init S3 client

--- a/pipelinewise/fastsync/commons/target_snowflake.py
+++ b/pipelinewise/fastsync/commons/target_snowflake.py
@@ -31,7 +31,9 @@ class FastSyncTargetSnowflake:
         # Get the required parameters from config file and/or environment variables
         aws_session_params = dict()
         for val in ("aws_profile", "aws_access_key_id", "aws_secret_access_key", "aws_session_token"):
-            if found_val := self.connection_config.get(val) or os.environ.get(val.upper()):
+            found_val = self.connection_config.get(val) or os.environ.get(val.upper())
+            if found_val:
+                val = "profile_name" if val == "aws_profile" else val
                 aws_session_params[val] = found_val
 
         # AWS credentials based authentication


### PR DESCRIPTION
## Problem

Walrus operator is used in code but not supported for python 3.7 (used in PPW cartridge).
for AWS connection, the session parameter key for `aws_profile` is `profile_name`

## Types of changes

What types of changes does your code introduce to PipelineWise?
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
