### PR TITLE
DATA-1281: Removed pip3 2020-resolver flags

### DIFF
--- a/exo_install.sh
+++ b/exo_install.sh
@@ -24,7 +24,7 @@ make_virtualenv() {
     python3 -m pip install --upgrade pip setuptools 
     if [ -f "setup.py" ]; then
         echo "Installing pipelinewise package venv"
-        python3 -m pip install --upgrade -e . --use-feature=2020-resolver
+        python3 -m pip install --upgrade -e .
     else
         echo "Installing via requirements.txt"
         python3 -m pip install -r requirements.txt || $FAILED_INSTALLS += $1

--- a/install.sh
+++ b/install.sh
@@ -70,7 +70,7 @@ make_virtualenv() {
             PIP_ARGS=$PIP_ARGS"[test]"
         fi
 
-        python3 -m pip install --upgrade -e .$PIP_ARGS --use-feature=2020-resolver
+        python3 -m pip install --upgrade -e .$PIP_ARGS
     fi
 
     echo ""


### PR DESCRIPTION
## Problem

2020 pip resolver option not supported in pip version 20.3

## Proposed changes
Remove the resolver flag. https://health-union.atlassian.net/browse/DATA-1281


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
