### PR TITLE
Allow fastsync for initial load when snowpipe is enabled

### DIFF
--- a/pipelinewise/cli/pipelinewise.py
+++ b/pipelinewise/cli/pipelinewise.py
@@ -136,13 +136,10 @@ class PipelineWise:
         f_tap_type = filters.get('tap_type', None)
         f_replication_method = filters.get('replication_method', None)
         f_initial_sync_required = filters.get('initial_sync_required', None)
-        f_load_via_snowpipe = filters.get('load_via_snowpipe', None)
 
         # Lists of tables that meet and don't meet the filter criteria
         filtered_tap_stream_ids = []
         fallback_filtered_stream_ids = []
-
-        load_via_snowpipe = utils.load_json(target_config).get('load_via_snowpipe', False)
 
         self.logger.debug('Filtering properties JSON by conditions: %s', filters)
         try:
@@ -205,8 +202,7 @@ class PipelineWise:
                         (f_target_type is None or target_type in f_target_type) and
                         (f_tap_type is None or tap_type in f_tap_type) and
                         (f_replication_method is None or replication_method in f_replication_method) and
-                        (f_initial_sync_required is None or initial_sync_required == f_initial_sync_required) and
-                        (f_load_via_snowpipe is None or load_via_snowpipe == f_load_via_snowpipe)
+                        (f_initial_sync_required is None or initial_sync_required == f_initial_sync_required)
                 ):
                     self.logger.debug("""Filter condition(s) matched:
                         Table              : %s
@@ -984,7 +980,6 @@ class PipelineWise:
                 'target_type': ['target-snowflake', 'target-redshift', 'target-postgres'],
                 'tap_type': ['tap-mysql', 'tap-postgres', 'tap-s3-csv', 'tap-mongodb'],
                 'initial_sync_required': True,
-                'load_via_snowpipe': False
             },
             create_fallback=True)
 


### PR DESCRIPTION
## Problem

Singer full table sync doesn't work for large tables in exo (ex: >16m skinny table in mysql)

## Proposed changes

Don't skip fastsync steps when using snowpipe.