### PR TITLE
DATA-2508 forked tap for mongodb + update git protocol

### DIFF
--- a/singer-connectors/tap-google-sheets/requirements.txt
+++ b/singer-connectors/tap-google-sheets/requirements.txt
@@ -1,1 +1,1 @@
-git+git://github.com/Health-Union/tap-google-sheets@v1.0.6-hu
+git+https://github.com/Health-Union/tap-google-sheets.git@v1.0.6-hu

--- a/singer-connectors/tap-mongodb/requirements.txt
+++ b/singer-connectors/tap-mongodb/requirements.txt
@@ -1,1 +1,1 @@
-pipelinewise-tap-mongodb==1.2.0
+git+https://github.com/Health-Union/pipelinewise-tap-mongodb.git@Connection-support

--- a/singer-connectors/target-snowflake/requirements.txt
+++ b/singer-connectors/target-snowflake/requirements.txt
@@ -1,1 +1,1 @@
-git+git://github.com/Health-Union/pipelinewise-target-snowflake
+git+https://github.com/Health-Union/pipelinewise-target-snowflake.git


### PR DESCRIPTION
1. **git** protocol to **https** protocol, since **git** is deprecated 
2. Tap mongodb install from our forked repo, for better connection support