### PR TITLE
DATA-9664: few more chages required for mysql2snowflake

### DIFF
--- a/pipelinewise/fastsync/mongodb_to_snowflake.py
+++ b/pipelinewise/fastsync/mongodb_to_snowflake.py
@@ -28,7 +28,6 @@ REQUIRED_CONFIG_KEYS = {
         'account',
         'dbname',
         'user',
-        'password',
         'warehouse',
         's3_bucket',
         'stage',

--- a/pipelinewise/fastsync/mysql_to_snowflake.py
+++ b/pipelinewise/fastsync/mysql_to_snowflake.py
@@ -22,7 +22,6 @@ REQUIRED_CONFIG_KEYS = {
         'account',
         'dbname',
         'user',
-        'password',
         'warehouse',
         's3_bucket',
         'stage',


### PR DESCRIPTION
## Problem

To improve the security posture of all of its customers, Snowflake is rolling out changes to require multi-factor authentication (MFA) for all human users using passwords, and disallow passwords for all service users. These changes will be rolled out across multiple behavior change releases (BCRs).

## Proposed changes

Utilise only the Snowflake service user(s) to initiate the handshake with Snowflake. 
The requirement involves transitioning to a key-based authentication approach.

